### PR TITLE
Export resetINP from attribution build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "web-vitals",
-  "version": "3.5.2",
+  "name": "@descript/web-vitals",
+  "version": "3.5.2-descript.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "web-vitals",
-      "version": "3.5.2",
+      "name": "@descript/web-vitals",
+      "version": "3.5.2-descript.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.23.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@descript/web-vitals",
-  "version": "3.5.2-descript.1",
+  "version": "3.5.2-descript.2",
   "description": "Easily measure performance metrics in JavaScript",
   "type": "module",
   "typings": "dist/modules/index.d.ts",

--- a/src/attribution.ts
+++ b/src/attribution.ts
@@ -24,7 +24,7 @@ export {onTTFB} from './attribution/onTTFB.js';
 export {CLSThresholds} from './onCLS.js';
 export {FCPThresholds} from './onFCP.js';
 export {FIDThresholds} from './onFID.js';
-export {INPThresholds} from './onINP.js';
+export {INPThresholds, resetINP} from './onINP.js';
 export {LCPThresholds} from './onLCP.js';
 export {TTFBThresholds} from './onTTFB.js';
 


### PR DESCRIPTION
Forgot to export `resetINP` from the attribution build.